### PR TITLE
Introduce Guice DI to the broker; layer on top of the rule customizer SPI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,21 @@ repo. It is intentionally short and focused on day-to-day work.
 - Prefer imports over fully qualified class names (e.g., use `import com.foo.Bar` and refer to `Bar`, not `com.foo.Bar` inline).
 - Prefer targeted unit tests; use integration tests when behavior crosses roles.
 
+### Dependency injection (Guice)
+Pinot is incrementally adopting Guice (broker first; server/controller/minion later).
+**Read `docs/dependency-injection.md` before adding Guice-related code.** Hard rules:
+
+- Constructor injection only — no field injection in production code, no setter injection.
+- Constructors must be side-effect-free; move global-state mutation / I/O / thread starts to an explicit `install...()` or `start()` method.
+- `@Singleton` is the only allowed scope. No request scope, no query scope, no custom scopes.
+- No AOP, no method interception, no proxies (`bindInterceptor` is forbidden).
+- `pinot-spi` stays Guice-free; SPI types live in their semantic module (`pinot-common`, `pinot-broker`, …).
+- Plugins contribute via a `Module` discovered through `ServiceLoader<Module>`. Plugins must not shade Guice; the broker exports `com.google.inject`, `jakarta.inject`, and `javax.inject` to plugin classloaders.
+- Operator config keys are permanent operational levers, not legacy. When a class needs operational config, route it through DI: bind `PinotConfiguration` into the injector and let the class `@Inject PinotConfiguration` to read it.
+- Multibinder iteration order is binding order; if order matters across plugins, add an explicit ordering hook on the SPI.
+
+Worked example: the multi-stage planner Calcite rule extension — `RuleSetCustomizer` SPI in `pinot-query-planner`, consumed by `PinotRuleSet` (`@Singleton`), seeded by `DefaultRuleSetCustomizer` (bound first in `PinotBrokerCoreModule`).
+
 ## Checkstyle config
 - Checkstyle rules and related config files live under `config/`.
 - Use the Maven wrapper (`./mvnw` on Unix-like systems or `mvnw.cmd` on Windows) to run `spotless:apply` to format code and `checkstyle:check` to validate style.

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -266,6 +266,7 @@ com.google.http-client:google-http-client-appengine:2.0.3
 com.google.http-client:google-http-client-gson:2.0.3
 com.google.http-client:google-http-client-jackson2:2.0.3
 com.google.http-client:google-http-client:2.0.3
+com.google.inject:guice:7.0.0
 com.google.j2objc:j2objc-annotations:3.1
 com.google.oauth-client:google-oauth-client:1.39.0
 com.google.uzaygezen:uzaygezen-core:0.2

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -1063,6 +1063,10 @@ Google Guava Version 18.0
 * License: Apache License, 2.0
 * Copyright (C) 2009 The Guava Authors
 
+Google Guice Version 7.0.0
+* License: Apache License, 2.0
+* Copyright (C) 2006 Google Inc.
+
 javax.inject Version: 1
 * License: Apache License, 2.0
 * Copyright (C) 2009 The JSR-330 Expert Group

--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -1,0 +1,219 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Dependency injection in Pinot
+
+> **Status**: incremental rollout. Today (broker only) Pinot uses [Guice 7] to wire a
+> small, growing set of singletons. This document captures the conventions all new
+> Guice-related code must follow. As more roles (server, controller, minion) and
+> more singletons migrate, this document evolves with them.
+
+[Guice 7]: https://github.com/google/guice
+
+## Why Guice
+
+Pinot has accumulated several extension-point patterns (`*Factory.init(String)` with
+reflection, `ServiceLoader` lookups, `static getDefault()` singletons). They are hard
+to test, hard to extend from a plugin without patching OSS, and hide their
+dependencies. Guice gives us:
+
+- **Constructor injection** — every dependency is visible in the signature, no
+  hidden static state.
+- **One discovery mechanism** — plugins contribute bindings via a Guice `Module`
+  instead of inventing per-feature config keys, `META-INF/services` files, or
+  reflection-based factories.
+- **Type-safe composition** — the binding graph is checked at injector
+  construction; missing dependencies fail fast at startup, not on the first query.
+
+Guice's footprint is intentionally small: one `Injector` per role process, no AOP,
+no scopes beyond `@Singleton`, no field injection in production code. It runs above
+the planner and stays out of the per-query hot path.
+
+## Conventions
+
+These rules apply to every new Guice-using class.
+
+### 1. Constructor injection only
+
+```java
+@Singleton
+public class FooFactory {
+  private final Set<Foo> _foos;
+
+  @Inject
+  public FooFactory(Set<Foo> foos) {
+    _foos = List.copyOf(foos);
+  }
+}
+```
+
+- Field injection is **forbidden in production code**. It hides dependencies, breaks
+  immutability, and prevents `final` fields. Only `src/test/java` may use field
+  injection if a test framework requires it.
+- No setter injection.
+- No `@Inject` on private constructors.
+
+### 2. Constructors must be side-effect-free
+
+A class created by Guice may be instantiated multiple times during testing (multiple
+injectors in the same JVM). Constructors must not mutate global state, register with
+external services, or start threads. Move side effects into a separately-callable
+method that the bootstrapping code invokes once.
+
+### 3. Scopes: `@Singleton` only
+
+Pinot's roles are long-lived processes; almost every binding is a singleton. Do not
+introduce request scope, query scope, or any other custom scope — pass per-request
+state explicitly through method parameters (`QueryContext`, `RequestContext`, etc.).
+
+### 4. No AOP, no method interception, no proxies
+
+Guice supports method interception via `bindInterceptor(...)`. **Don't use it.** It
+creates synthetic subclasses, complicates stack traces, and is a per-call
+performance trap. If cross-cutting behavior is needed (metrics, tracing), wrap the
+collaborator explicitly in a decorator class.
+
+### 5. SPI types live in their semantic module, not in `pinot-spi`
+
+`pinot-spi` is the slim, plugin-facing contract module — it must not depend on
+Guice. Plugin-contributed Guice bindings (multibinders, modules) live in higher
+modules (`pinot-common`, `pinot-broker`, …). Plugins still depend only on
+`pinot-spi` plus any module that owns the SPI they implement.
+
+### 6. Plugins contribute via a `Module` discovered through `ServiceLoader`
+
+Each role's injector walks its plugin classloaders at startup with
+`ServiceLoader.load(Module.class, pluginClassLoader)`. A plugin contributes by:
+
+1. Adding a `Module` class.
+2. Listing it in
+   `src/main/resources/META-INF/services/com.google.inject.Module`.
+
+Plugins must **not** shade Guice. The role classloader exports
+`com.google.inject`, `jakarta.inject`, and `javax.inject` to plugin realms, so the
+core and plugin Modules see the same `Class<?>` objects.
+
+### 7. Multibinder iteration order is binding order
+
+Guice's `Multibinder<T>` produces a `Set<T>` whose iteration order is the order in
+which bindings were added. Within a single `Module`, that's source order. Across
+multiple `Module`s, OSS-core bindings come first, plugin bindings after.
+
+If your code depends on **specific** ordering (e.g. rewriter A must run before B),
+either bind both in the same Module in the right order, or introduce an explicit
+ordering hook on the SPI (`int order()`) — don't rely on incidental Set iteration.
+
+### 8. Operational config keys are first-class, not legacy
+
+Config keys that control runtime behavior (rule lists, thresholds, class name
+overrides) are permanent operator levers — they let an operator hot-fix behavior by
+editing config and restarting, without a binary release. When a class needs
+operational config, route it through DI: bind `PinotConfiguration` into the injector
+and let the class `@Inject PinotConfiguration` to read it. Don't recreate
+config-reading boilerplate per-class.
+
+## Worked example: Calcite rule customization
+
+The canonical demo of these conventions is the multi-stage planner's Calcite rule
+extension point.
+
+| Type | Where | What |
+| ---- | ----- | ---- |
+| `Phase` | `pinot-query-planner/.../planner/rules/` | Top-level enum, append-only, one value per HEP slot |
+| `RuleSetCustomizer` | same package | SPI: `void customize(Phase, List<RelOptRule>)` — plugins mutate the list in place |
+| `PinotRuleSet` | same package | `@Singleton` service, `@Inject` ctor takes `Set<RuleSetCustomizer>`, applies them in iteration order, freezes per-phase lists |
+| `DefaultRuleSetCustomizer` | same package | `RuleSetCustomizer` that owns and seeds every `Phase` with the OSS default rules. Bound first in `PinotBrokerCoreModule` so plugins observe pre-populated lists |
+| `PinotBrokerCoreModule` | `pinot-broker/.../runtime/` | Binds `PinotConfiguration`, declares `Multibinder<RuleSetCustomizer>`, binds `DefaultRuleSetCustomizer` |
+| `QueryEnvironment.Config` | `pinot-query-planner/.../query/` | `PinotRuleSet getRuleSet()` accessor; `getOptProgram` / `getTraitProgram` read every phase from it |
+
+Plugins customize without patching OSS:
+
+```java
+public class MyPluginRules implements RuleSetCustomizer {
+  @Override public void customize(Phase phase, List<RelOptRule> rules) {
+    if (phase == Phase.BASIC) {
+      rules.add(MyOptimizationRule.INSTANCE);
+      rules.removeIf(r -> "BadOldRule".equals(r.toString()));
+    }
+  }
+}
+
+public class MyPluginModule extends AbstractModule {
+  @Override protected void configure() {
+    Multibinder.newSetBinder(binder(), RuleSetCustomizer.class)
+        .addBinding().to(MyPluginRules.class);
+  }
+}
+```
+
+Per-query `usePlannerRules` / `skipPlannerRules` query options still apply on top via
+the existing `QueryEnvironment#filterRuleList` (a copy + filter applied to the
+result of `PinotRuleSet#rulesFor(phase)`).
+
+## Where bindings live
+
+| Module                | What it binds                                                                            |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| `pinot-spi`           | Nothing (Guice-free; plugin-classloader hooks only).                                      |
+| `pinot-common`        | Generic helpers: `PinotInjectors.createWithPluginModules`, `PinotPluginModules.discover`. |
+| `pinot-query-planner` | `RuleSetCustomizer` SPI, `Phase`, `PinotRuleSet`, `DefaultRuleSetCustomizer`.              |
+| `pinot-broker`        | `PinotBrokerCoreModule` — broker singletons + `Multibinder<RuleSetCustomizer>`.           |
+| `pinot-server`        | _(future)_ `PinotServerCoreModule`.                                                       |
+| `pinot-controller`    | _(future)_ `PinotControllerCoreModule`.                                                   |
+| `pinot-minion`        | _(future)_ `PinotMinionCoreModule`.                                                       |
+
+Each role builds its injector once at startup with
+`PinotInjectors.createWithPluginModules(coreModule)`.
+
+## What this is not
+
+- Not a replacement for `ServiceLoader` everywhere — `ServiceLoader` still discovers
+  plugin `Module`s themselves; only what the modules contribute (`RuleSetCustomizer`,
+  …) flows through Multibinders.
+- Not a replacement for HK2/Jersey on the REST resource graph — Jersey continues to
+  manage its own injection.
+- Not a request-scoping framework — there is no per-query injector, no
+  `@RequestScoped`. Per-query state is passed explicitly through method arguments.
+- Not used in the per-row / per-segment hot path — adapters and operators are
+  resolved at planning time, never at execution time.
+
+## Backwards compatibility
+
+- **Guice is role-local**: changes to a role's `*CoreModule` do not affect wire
+  protocols or serialization. Mixed-version clusters can upgrade roles independently.
+- **Plugins shipping their own shaded Guice** will fail at injector build time with
+  `ClassCastException`. The fix is to remove the shade and depend on Pinot-provided
+  Guice.
+- **OSS default behavior must be preserved**: when seeding a new `Multibinder`, bind
+  the OSS default implementation first so plugins always observe a pre-populated list.
+
+## Adding a new binding (checklist)
+
+When you add a new `@Inject`-annotated class or extend a `Multibinder`:
+
+- [ ] Constructor only, no field injection (production).
+- [ ] No mutation of global state in the constructor; if you must publish, expose
+      a separate explicit method.
+- [ ] `@Singleton` if process-lifetime; never request/query scope.
+- [ ] Bound in the appropriate `*CoreModule`, or contributed via Multibinder if
+      it's an extension-point set.
+- [ ] If a new Multibinder type is added, declare an empty multibinder in the core
+      module so `Set<T>` is always injectable.
+- [ ] Tests run `Guice.createInjector(coreModule, testModule)` and assert behavior;
+      never `static init(...)` from inside the binding's constructor.

--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -49,6 +49,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.broker.helix;
 
 import com.google.common.base.Preconditions;
+import com.google.inject.Injector;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -62,6 +63,7 @@ import org.apache.pinot.broker.requesthandler.SingleConnectionBrokerRequestHandl
 import org.apache.pinot.broker.requesthandler.TimeSeriesRequestHandler;
 import org.apache.pinot.broker.routing.manager.BrokerRoutingManager;
 import org.apache.pinot.broker.routing.tablesampler.TableSamplerFactory;
+import org.apache.pinot.broker.runtime.PinotBrokerCoreModule;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.audit.AuditServiceBinder;
 import org.apache.pinot.common.config.DefaultClusterConfigChangeHandler;
@@ -79,6 +81,7 @@ import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.BrokerTimer;
+import org.apache.pinot.common.plugin.PinotInjectors;
 import org.apache.pinot.common.utils.PinotAppConfigs;
 import org.apache.pinot.common.utils.ServiceStartableUtils;
 import org.apache.pinot.common.utils.ServiceStatus;
@@ -98,6 +101,7 @@ import org.apache.pinot.core.transport.NettyInspector;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.core.util.trace.ContinuousJfrStarter;
+import org.apache.pinot.query.planner.rules.PinotRuleSet;
 import org.apache.pinot.query.routing.WorkerManager;
 import org.apache.pinot.query.runtime.operator.factory.DefaultQueryOperatorFactoryProvider;
 import org.apache.pinot.query.runtime.operator.factory.QueryOperatorFactoryProvider;
@@ -189,6 +193,13 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   protected BrokerGrpcServer _brokerGrpcServer;
   protected FailureDetector _failureDetector;
   protected ThreadAccountant _threadAccountant;
+  /**
+   * Broker-wide Guice injector. Built lazily during {@link #start()} once the broker
+   * config and plugin classloaders are available; null before that. Subclasses
+   * extending the broker must not rebind types already bound by
+   * {@link PinotBrokerCoreModule}.
+   */
+  protected Injector _brokerInjector;
 
   @Override
   public void init(PinotConfiguration brokerConf)
@@ -304,10 +315,10 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       QueryQuotaManager queryQuotaManager, TableCache tableCache,
       MultiStageQueryThrottler multiStageQueryThrottler, FailureDetector failureDetector,
       ThreadAccountant threadAccountant, MultiClusterRoutingContext multiClusterRoutingContext,
-      WorkerManager workerManager, WorkerManager multiClusterWorkerManager) {
+      WorkerManager workerManager, WorkerManager multiClusterWorkerManager, PinotRuleSet ruleSet) {
     return new MultiStageBrokerRequestHandler(config, brokerId, requestIdGenerator, routingManager,
         accessControlFactory, queryQuotaManager, tableCache, multiStageQueryThrottler, failureDetector,
-        threadAccountant, multiClusterRoutingContext, workerManager, multiClusterWorkerManager);
+        threadAccountant, multiClusterRoutingContext, workerManager, multiClusterWorkerManager, ruleSet);
   }
 
   private void setupHelixSystemProperties() {
@@ -468,6 +479,13 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     // TODO: Hook multiClusterRoutingContext into request handlers subsequently.
     MultiClusterRoutingContext multiClusterRoutingContext = getMultiClusterRoutingContext();
 
+    // Build the broker-wide Guice injector. PinotBrokerCoreModule binds _brokerConf
+    // as PinotConfiguration plus broker-specific bindings (the Multibinder of
+    // RuleSetCustomizer, seeded with DefaultRuleSetCustomizer); plugins contribute
+    // additional bindings via Modules exposed as ServiceLoader entries on each
+    // plugin classloader.
+    _brokerInjector = PinotInjectors.createWithPluginModules(new PinotBrokerCoreModule(_brokerConf));
+
     // Create Broker request handler.
     String brokerId = _brokerConf.getProperty(Broker.CONFIG_OF_BROKER_ID, getDefaultBrokerId());
     BrokerRequestIdGenerator requestIdGenerator = new BrokerRequestIdGenerator();
@@ -526,7 +544,8 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       multiStageBrokerRequestHandler =
           createMultiStageBrokerRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, _multiStageQueryThrottler, _failureDetector,
-              _threadAccountant, multiClusterRoutingContext, workerManager, multiClusterWorkerManager);
+              _threadAccountant, multiClusterRoutingContext, workerManager, multiClusterWorkerManager,
+              _brokerInjector.getInstance(PinotRuleSet.class));
       MultiStageBrokerRequestHandler finalHandler = multiStageBrokerRequestHandler;
       _routingManager.setServerReenableCallback(
           serverInstance -> finalHandler.getQueryDispatcher().resetClientConnectionBackoff(serverInstance));

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -81,6 +82,7 @@ import org.apache.pinot.query.planner.explain.AskingServerStageExplainer;
 import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
 import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.planner.rules.PinotRuleSet;
 import org.apache.pinot.query.routing.QueryServerInstance;
 import org.apache.pinot.query.routing.WorkerManager;
 import org.apache.pinot.query.runtime.MultiStageStatsTreeBuilder;
@@ -136,6 +138,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   private final MultiStageQueryThrottler _queryThrottler;
   private final ExecutorService _queryCompileExecutor;
   private final Set<String> _defaultDisabledPlannerRules;
+  private final PinotRuleSet _ruleSet;
   protected final long _extraPassiveTimeoutMs;
   protected final boolean _enableQueryFingerprinting;
 
@@ -149,9 +152,11 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, TableCache tableCache,
       MultiStageQueryThrottler queryThrottler, FailureDetector failureDetector, ThreadAccountant threadAccountant,
       MultiClusterRoutingContext multiClusterRoutingContext,
-      WorkerManager workerManager, WorkerManager multiClusterWorkerManager) {
+      WorkerManager workerManager, WorkerManager multiClusterWorkerManager,
+      PinotRuleSet ruleSet) {
     super(config, brokerId, requestIdGenerator, routingManager, accessControlFactory, queryQuotaManager, tableCache,
         threadAccountant, multiClusterRoutingContext);
+    _ruleSet = Objects.requireNonNull(ruleSet, "ruleSet");
     String hostname = config.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME);
     int port = Integer.parseInt(config.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT));
 
@@ -537,6 +542,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         .defaultHashFunction(defaultHashFunction)
         .defaultDisabledPlannerRules(_defaultDisabledPlannerRules)
         .defaultSortExchangeCopyLimit(sortExchangeCopyThreshold)
+        .ruleSet(_ruleSet)
         .build();
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/runtime/PinotBrokerCoreModule.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/runtime/PinotBrokerCoreModule.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.runtime;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import java.util.Objects;
+import org.apache.pinot.query.planner.rules.DefaultRuleSetCustomizer;
+import org.apache.pinot.query.planner.rules.RuleSetCustomizer;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/// Core Guice module for broker-specific bindings.
+///
+/// Today the module binds:
+///
+/// - The broker's [PinotConfiguration] as the singleton instance constructed
+///   from the broker startup config. Any class created by this injector can
+///   read role config via `@Inject PinotConfiguration`.
+/// - A `Multibinder<RuleSetCustomizer>` seeded with [DefaultRuleSetCustomizer]
+///   as the first contribution. Plugins layer additional `RuleSetCustomizer`
+///   bindings on top from their own `Module`s; the multibinder's iteration
+///   order is binding order, so plugins always observe a list pre-populated
+///   with the OSS defaults.
+///
+/// Over time this module will grow to bind more broker singletons as Pinot's
+/// DI footprint expands.
+public class PinotBrokerCoreModule extends AbstractModule {
+
+  private final PinotConfiguration _brokerConf;
+
+  public PinotBrokerCoreModule(PinotConfiguration brokerConf) {
+    _brokerConf = Objects.requireNonNull(brokerConf, "brokerConf");
+  }
+
+  @Override
+  protected void configure() {
+    bind(PinotConfiguration.class).toInstance(_brokerConf);
+
+    // Calcite rule extension point for the multi-stage engine. PinotRuleSet
+    // (auto-bound @Singleton) consumes the multibound set, applies all
+    // customizers in iteration order, and exposes the frozen per-phase lists
+    // to QueryEnvironment. DefaultRuleSetCustomizer is bound first so every
+    // plugin customizer observes a list pre-populated with the OSS defaults.
+    Multibinder<RuleSetCustomizer> ruleCustomizers = Multibinder.newSetBinder(binder(), RuleSetCustomizer.class);
+    ruleCustomizers.addBinding().to(DefaultRuleSetCustomizer.class);
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandlerTest.java
@@ -31,6 +31,7 @@ import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNativeV2;
 import org.apache.pinot.core.routing.RoutingManager;
+import org.apache.pinot.query.planner.rules.PinotRuleSet;
 import org.apache.pinot.query.routing.WorkerManager;
 import org.apache.pinot.spi.accounting.ThreadAccountantUtils;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
@@ -73,7 +74,8 @@ public class MultiStageBrokerRequestHandlerTest {
         new MultiStageBrokerRequestHandler(config, "testBrokerId", new BrokerRequestIdGenerator(),
             mock(RoutingManager.class), new AllowAllAccessControlFactory(), queryQuotaManager,
             mock(TableCache.class), mock(MultiStageQueryThrottler.class), mock(FailureDetector.class),
-            ThreadAccountantUtils.getNoOpAccountant(), null, mock(WorkerManager.class), mock(WorkerManager.class)) {
+            ThreadAccountantUtils.getNoOpAccountant(), null, mock(WorkerManager.class), mock(WorkerManager.class),
+            PinotRuleSet.defaultInstance()) {
           @Override
           public void start() {
             // Skip dispatcher.start() and Calcite warmupCompile — neither is needed for this hook test.

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/runtime/PinotBrokerCoreModuleTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/runtime/PinotBrokerCoreModuleTest.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.runtime;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.multibindings.Multibinder;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.pinot.query.planner.rules.Phase;
+import org.apache.pinot.query.planner.rules.PinotRuleSet;
+import org.apache.pinot.query.planner.rules.RuleSetCustomizer;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+
+/// Verifies bindings on [PinotBrokerCoreModule]: [PinotConfiguration]
+/// availability for downstream `@Inject` consumers, and the
+/// [RuleSetCustomizer] / [PinotRuleSet] extension point.
+public class PinotBrokerCoreModuleTest {
+
+  @Test
+  public void ossDefaultsSeedEveryPhase() {
+    Injector injector = Guice.createInjector(new PinotBrokerCoreModule(new PinotConfiguration()));
+    PinotRuleSet ruleSet = injector.getInstance(PinotRuleSet.class);
+
+    assertFalse(ruleSet.rulesFor(Phase.BASIC).isEmpty(), "BASIC should be populated");
+    assertFalse(ruleSet.rulesFor(Phase.FILTER_PUSHDOWN).isEmpty(), "FILTER_PUSHDOWN should be populated");
+    assertFalse(ruleSet.rulesFor(Phase.PROJECT_PUSHDOWN).isEmpty(), "PROJECT_PUSHDOWN should be populated");
+    assertFalse(ruleSet.rulesFor(Phase.PRUNE).isEmpty(), "PRUNE should be populated");
+    assertFalse(ruleSet.rulesFor(Phase.POST_LOGICAL).isEmpty(), "POST_LOGICAL should be populated");
+    assertFalse(ruleSet.rulesFor(Phase.POST_LOGICAL_V2).isEmpty(), "POST_LOGICAL_V2 should be populated");
+    assertFalse(ruleSet.rulesFor(Phase.POST_LOGICAL_ENRICHED_JOIN).isEmpty(),
+        "POST_LOGICAL_ENRICHED_JOIN should be populated");
+  }
+
+  @Test
+  public void pluginCustomizerCanAppendToBasicAfterOssDefaults() {
+    // Capture baseline from a plain injector, then verify plugin appended one more rule.
+    Injector baseInjector = Guice.createInjector(new PinotBrokerCoreModule(new PinotConfiguration()));
+    PinotRuleSet baseRuleSet = baseInjector.getInstance(PinotRuleSet.class);
+    int ossSize = baseRuleSet.rulesFor(Phase.BASIC).size();
+    RelOptRule extraRule = baseRuleSet.rulesFor(Phase.BASIC).get(0);
+
+    RuleSetCustomizer customizer = (phase, rules) -> {
+      if (phase == Phase.BASIC) {
+        rules.add(extraRule);
+      }
+    };
+
+    Injector injector = Guice.createInjector(
+        new PinotBrokerCoreModule(new PinotConfiguration()),
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            Multibinder.newSetBinder(binder(), RuleSetCustomizer.class).addBinding().toInstance(customizer);
+          }
+        });
+
+    PinotRuleSet ruleSet = injector.getInstance(PinotRuleSet.class);
+    assertEquals(ruleSet.rulesFor(Phase.BASIC).size(), ossSize + 1);
+    assertSame(ruleSet.rulesFor(Phase.BASIC).get(ossSize), extraRule);
+  }
+
+  @Test
+  public void pluginCustomizerCanRemoveOssDefault() {
+    Injector baseInjector = Guice.createInjector(new PinotBrokerCoreModule(new PinotConfiguration()));
+    PinotRuleSet baseRuleSet = baseInjector.getInstance(PinotRuleSet.class);
+    // Pick the concrete rule class of the first OSS-default rule and remove every rule of that
+    // exact class. Class identity is a stronger signal than toString() — Calcite rule names are
+    // not guaranteed unique.
+    Class<?> targetClass = baseRuleSet.rulesFor(Phase.BASIC).get(0).getClass();
+    int ossSize = baseRuleSet.rulesFor(Phase.BASIC).size();
+    long ossInstancesOfTarget = baseRuleSet.rulesFor(Phase.BASIC).stream()
+        .filter(r -> r.getClass() == targetClass)
+        .count();
+
+    RuleSetCustomizer customizer = (phase, rules) -> {
+      if (phase == Phase.BASIC) {
+        rules.removeIf(r -> r.getClass() == targetClass);
+      }
+    };
+
+    Injector injector = Guice.createInjector(
+        new PinotBrokerCoreModule(new PinotConfiguration()),
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            Multibinder.newSetBinder(binder(), RuleSetCustomizer.class).addBinding().toInstance(customizer);
+          }
+        });
+
+    PinotRuleSet ruleSet = injector.getInstance(PinotRuleSet.class);
+    assertEquals(ruleSet.rulesFor(Phase.BASIC).size(), ossSize - (int) ossInstancesOfTarget);
+    assertTrue(ruleSet.rulesFor(Phase.BASIC).stream().noneMatch(r -> r.getClass() == targetClass));
+  }
+
+  @Test
+  public void pinotRuleSetIsSingletonAcrossLookups() {
+    Injector injector = Guice.createInjector(new PinotBrokerCoreModule(new PinotConfiguration()));
+    PinotRuleSet first = injector.getInstance(PinotRuleSet.class);
+    PinotRuleSet second = injector.getInstance(PinotRuleSet.class);
+    assertSame(first, second);
+  }
+
+  @Test
+  public void brokerConfigIsAvailableForInjection() {
+    PinotConfiguration brokerConf = new PinotConfiguration();
+    Injector injector = Guice.createInjector(new PinotBrokerCoreModule(brokerConf));
+    assertSame(injector.getInstance(PinotConfiguration.class), brokerConf);
+  }
+}

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -140,6 +140,10 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-timeseries-spi</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/pinot-common/src/main/java/org/apache/pinot/common/plugin/PinotInjectors.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/plugin/PinotInjectors.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.plugin;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.apache.pinot.spi.plugin.PluginManager;
+
+
+/// Builds Pinot's role-level Guice injectors.
+///
+/// Each Pinot role (broker, server, controller, minion) constructs a single
+/// process-wide [Injector] at startup. The injector wires together:
+///
+/// 1. Role-level core modules supplied by the caller (e.g. the broker's
+///    `PinotBrokerCoreModule`).
+/// 2. Plugin-contributed [Module]s discovered by [PinotPluginModules].
+///
+/// Plugins run AFTER the core modules so plugin bindings can observe and
+/// extend any `Multibinder` declared by the core. The OSS-default bindings
+/// for an extension point therefore live in the core module and plugins
+/// layer additional contributions on top.
+///
+/// This class is stateless. Each call builds a fresh injector and re-walks
+/// every plugin classloader, so callers should invoke it once per role
+/// process at startup and reuse the returned [Injector] for the lifetime of
+/// the JVM.
+public final class PinotInjectors {
+
+  private PinotInjectors() {
+  }
+
+  /// Convenience overload: discovers plugin modules from
+  /// [PluginManager#get()].
+  public static Injector createWithPluginModules(Module... coreModules) {
+    return createWithPluginModules(PluginManager.get(), coreModules);
+  }
+
+  /// Builds an [Injector] composed of the supplied core modules followed by
+  /// every plugin-contributed [Module] discovered through `pluginManager`.
+  /// Order is significant: core modules run first, plugins run after.
+  public static Injector createWithPluginModules(PluginManager pluginManager, Module... coreModules) {
+    Objects.requireNonNull(pluginManager, "pluginManager");
+    Objects.requireNonNull(coreModules, "coreModules");
+    List<Module> modules = new ArrayList<>(coreModules.length);
+    for (int i = 0; i < coreModules.length; i++) {
+      modules.add(Objects.requireNonNull(coreModules[i], "coreModules[" + i + "]"));
+    }
+    modules.addAll(PinotPluginModules.discover(pluginManager));
+    return Guice.createInjector(modules);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/plugin/PinotPluginModules.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/plugin/PinotPluginModules.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.plugin;
+
+import com.google.inject.Module;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/// Discovers Guice [Module] instances contributed by Pinot plugins.
+///
+/// Each plugin classloader is walked with [ServiceLoader] for `Module`
+/// implementations declared in
+/// `META-INF/services/com.google.inject.Module`. Plugin authors register
+/// their `Module` there. The plugin classloaders themselves come from
+/// [PluginManager#getPluginClassLoaders()] and have already been wired so
+/// that `com.google.inject`, `jakarta.inject`, and `javax.inject` resolve
+/// to the same `Class<?>` objects in plugin and core code.
+///
+/// Iteration order is plugin-load order (LinkedHashMap in `PluginManager`),
+/// which is stable across JVMs for a given plugins directory.
+///
+/// This class is stateless and only loads once per call — callers that need
+/// caching should cache themselves.
+public final class PinotPluginModules {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotPluginModules.class);
+
+  private PinotPluginModules() {
+  }
+
+  /// Discovers every plugin-provided [Module] across all plugin classloaders
+  /// known to the supplied [PluginManager]. A plugin classloader whose
+  /// `ServiceLoader` lookup throws is logged and skipped.
+  public static List<Module> discover(PluginManager pluginManager) {
+    List<Module> modules = new ArrayList<>();
+    for (ClassLoader pluginClassLoader : pluginManager.getPluginClassLoaders()) {
+      try {
+        for (Module module : ServiceLoader.load(Module.class, pluginClassLoader)) {
+          LOGGER.info("Discovered Guice Module {} from plugin classloader {}",
+              module.getClass().getName(), pluginClassLoader);
+          modules.add(module);
+        }
+      } catch (Throwable t) {
+        LOGGER.warn("Failed to load Guice Modules from plugin classloader {}", pluginClassLoader, t);
+      }
+    }
+    return modules;
+  }
+}

--- a/pinot-query-planner/pom.xml
+++ b/pinot-query-planner/pom.xml
@@ -52,6 +52,10 @@
       <groupId>org.immutables</groupId>
       <artifactId>value-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/rules/PinotRuleSet.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/rules/PinotRuleSet.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pinot.query.planner.rules;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Set;
 import org.apache.calcite.plan.RelOptRule;
 
 
@@ -35,17 +38,28 @@ import org.apache.calcite.plan.RelOptRule;
 /// 1. Allocate an empty mutable list per [Phase].
 /// 2. For every [RuleSetCustomizer] (in supplied order), call
 ///    `customize(phase, list)` once per phase. The OSS defaults are themselves
-///    contributed by [DefaultRuleSetCustomizer] which is registered as a
-///    `ServiceLoader` entry; plugin customizers run after and observe a list
-///    pre-populated with the OSS defaults.
+///    contributed by [DefaultRuleSetCustomizer]. In the broker, the customizer
+///    set is supplied by Guice (a `Multibinder<RuleSetCustomizer>` populated
+///    by `PinotBrokerCoreModule` and any plugin `Module`s); other callers can
+///    use [#loadFromServiceLoader()] to discover customizers via
+///    `META-INF/services`.
 /// 3. Defensively copy each per-phase list to an immutable [List] and freeze
 ///    the map.
 ///
 /// `QueryEnvironment` reads `rulesFor(phase)` and applies per-query
 /// `usePlannerRules` / `skipPlannerRules` filters on top.
+@Singleton
 public final class PinotRuleSet {
 
   private final Map<Phase, List<RelOptRule>> _rulesByPhase;
+
+  /// Guice constructor: customizers come from a `Multibinder<RuleSetCustomizer>`
+  /// declared in the broker's core module. Multibinder iteration order is the
+  /// binding order: OSS defaults (bound first) run before plugin contributions.
+  @Inject
+  public PinotRuleSet(Set<RuleSetCustomizer> customizers) {
+    this((Iterable<RuleSetCustomizer>) customizers);
+  }
 
   /// Builds a rule set from the supplied customizers. Customizers run in the
   /// order of the iterable; the framework freezes the per-phase lists after

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -34,9 +34,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
@@ -139,7 +142,9 @@ public class PluginManager {
 
   PluginManager() {
     // For the shaded plugins
-    _registry = new HashMap<>();
+    // LinkedHashMap so plugin classloader iteration is stable for downstream
+    // consumers that walk plugins to discover services (e.g. Guice Modules).
+    _registry = new LinkedHashMap<>();
     _registry.put(new Plugin(DEFAULT_PLUGIN_NAME), createClassLoader(Collections.emptyList()));
 
     // for the new pinot plugins
@@ -264,7 +269,7 @@ public class PluginManager {
    * @param pluginName
    * @param directory the directory of one plugin
    */
-  public void load(String pluginName, File directory) {
+  public synchronized void load(String pluginName, File directory) {
     Path pluginPropertiesPath = directory.toPath().resolve(PINOUT_PLUGIN_PROPERTIES_FILE_NAME);
     if (Files.isRegularFile(pluginPropertiesPath)) {
       Properties pluginProperties = new Properties();
@@ -298,9 +303,16 @@ public class PluginManager {
 
         ClassRealm pinotRealm = _classWorld.getClassRealm(PINOT_REALMID);
 
-        // All packages to look up in pinot realm BEFORE itself
-        Stream<String> importedPinotPackages =
-            Stream.of("org.apache.pinot.spi"); // this works like a prefix, so ALL spi classes will be accessible
+        // All packages to look up in pinot realm BEFORE itself.
+        // Acts like a prefix so all classes in (and below) the listed packages are accessible.
+        // Guice and the standard inject-annotation namespaces are shared so plugin Modules
+        // bind against the same Class<?> objects as the broker injector — plugins must not
+        // shade Guice.
+        Stream<String> importedPinotPackages = Stream.of(
+            "org.apache.pinot.spi",
+            "com.google.inject",
+            "jakarta.inject",
+            "javax.inject");
         importedPinotPackages.forEach(p -> pluginRealm.importFrom(pinotRealm, p));
 
         // Additional importForm as specified by the plugin configuration
@@ -472,6 +484,28 @@ public class PluginManager {
       return _pluginsDirectories.split(";");
     }
     return null;
+  }
+
+  /**
+   * Returns a point-in-time snapshot of the classloaders backing every loaded plugin
+   * (excluding the shared default classloader). Iteration order follows plugin load
+   * order. Callers can use these to drive their own service discovery (e.g.
+   * {@link java.util.ServiceLoader#load(Class, ClassLoader)}) without coupling
+   * pinot-spi to the consumer's framework.
+   *
+   * <p>Intended to be called once at role startup after all plugins are loaded.
+   * The returned set is immutable; subsequent {@link #load(String, File)} calls
+   * are not reflected in previously returned snapshots.
+   */
+  public synchronized Set<ClassLoader> getPluginClassLoaders() {
+    Set<ClassLoader> classLoaders = new LinkedHashSet<>();
+    Plugin defaultPlugin = new Plugin(DEFAULT_PLUGIN_NAME);
+    for (Map.Entry<Plugin, PluginClassLoader> entry : _registry.entrySet()) {
+      if (!entry.getKey().equals(defaultPlugin)) {
+        classLoaders.add(entry.getValue());
+      }
+    }
+    return Collections.unmodifiableSet(classLoaders);
   }
 
   public static PluginManager get() {

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,7 @@
     <google.errorprone.version>2.49.0</google.errorprone.version>
     <google.j2objc.version>3.1</google.j2objc.version>
     <google.jsr305.version>3.0.2</google.jsr305.version>
+    <guice.version>7.0.0</guice.version>
 
     <!-- Configuration for Scala -->
     <scala-2.12.version>2.12.20</scala-2.12.version>
@@ -1480,6 +1481,19 @@
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>${google.jsr305.version}</version>
+      </dependency>
+
+      <!-- Guice for dependency injection. Pinned explicitly so Pinot is not
+           transitively dragged onto Hadoop's older Guice line. 7.0.0 is the
+           first release that exposes the jakarta.inject namespace; pairs with
+           our JDK 21 service code and JDK 11 SPI bytecode. PluginManager
+           exports com.google.inject and both jakarta.inject + javax.inject
+           into plugin classloaders so plugin Modules and the broker injector
+           bind against the same Class<?> objects. -->
+      <dependency>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>${guice.version}</version>
       </dependency>
 
       <!-- Hadoop -->
@@ -2992,6 +3006,9 @@
 
             <!-- Spark datasource register -->
             <exclude>**/org.apache.spark.sql.sources.DataSourceRegister</exclude>
+
+            <!-- ServiceLoader entries (plain text, single-line class names) -->
+            <exclude>**/src/main/resources/META-INF/services/**</exclude>
 
             <!-- Binary files -->
             <exclude>**/*.avro</exclude>


### PR DESCRIPTION
Builds on the previously-merged RuleSetCustomizer SPI. The broker now constructs a single Guice 7.0.0 injector at startup; PinotRuleSet is @Singleton with an @Inject Set<RuleSetCustomizer> constructor, and DefaultRuleSetCustomizer is bound first so plugins observe a list pre-populated with the OSS defaults.

This change has three logically distinct concerns; they are bundled in one PR but called out here for review:

1. Guice introduction
   - New PinotBrokerCoreModule binds PinotConfiguration and a Multibinder<RuleSetCustomizer> seeded with DefaultRuleSetCustomizer.
   - BaseBrokerStarter builds _brokerInjector via PinotInjectors.createWithPluginModules and resolves PinotRuleSet from it.
   - MultiStageBrokerRequestHandler accepts PinotRuleSet, forwards it to QueryEnvironment.Config#ruleSet.

2. PluginManager classloader policy (pinot-spi)
   - Imports com.google.inject, jakarta.inject, javax.inject from the pinot realm into every plugin classloader so plugin Modules and the core injector bind against the same Class<?> objects. Plugins must not shade Guice — see docs/dependency-injection.md "Backwards compatibility" section for the symptom (ClassCastException at injector build time) and the fix.
   - load() is now synchronized; getPluginClassLoaders() returns a point-in-time snapshot of plugin classloaders for ServiceLoader lookups.

3. Apache RAT exclude for META-INF/services entries
   - Plain-text service files cannot carry Apache headers; excluded under the standard pattern src/main/resources/META-INF/services/**.

New helpers in pinot-common:
- PinotInjectors.createWithPluginModules(Module... coreModules) builds a Guice injector from caller-supplied core modules + plugin-discovered Modules.
- PinotPluginModules.discover(PluginManager) walks every plugin classloader with ServiceLoader.load(Module.class, classLoader).

Documentation:
- docs/dependency-injection.md captures the conventions every new Guice-using class must follow (constructor injection only, no AOP, @Singleton only, plugins via ServiceLoader<Module>, Multibinder iteration order is binding order).
- AGENTS.md gets a "Dependency injection" section pointing at the doc.
